### PR TITLE
feat(enrollment-dashboard): scaffold Next.js app

### DIFF
--- a/apps/enrollment-dashboard/README.md
+++ b/apps/enrollment-dashboard/README.md
@@ -1,0 +1,36 @@
+This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+
+## Getting Started
+
+First, run the development server:
+
+```bash
+npm run dev
+# or
+yarn dev
+# or
+pnpm dev
+# or
+bun dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+
+## Learn More
+
+To learn more about Next.js, take a look at the following resources:
+
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+
+You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+
+## Deploy on Vercel
+
+The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+
+Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/apps/enrollment-dashboard/eslint.config.mjs
+++ b/apps/enrollment-dashboard/eslint.config.mjs
@@ -1,0 +1,26 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    ignores: [
+      "node_modules/**",
+      ".next/**",
+      "out/**",
+      "build/**",
+      "next-env.d.ts",
+      "public/**",
+    ],
+  },
+];
+
+export default eslintConfig;

--- a/apps/enrollment-dashboard/next.config.ts
+++ b/apps/enrollment-dashboard/next.config.ts
@@ -1,0 +1,21 @@
+import type { NextConfig } from "next";
+
+const isPreview = process.env.VERCEL_ENV === "preview";
+
+const nextConfig: NextConfig = {
+  basePath: "/enrollment-dashboard",
+  transpilePackages: ["@repo/ui", "@repo/backend"],
+  async redirects() {
+    return isPreview
+      ? [
+          {
+            source: "/",
+            destination: "/enrollment-dashboard",
+            permanent: false,
+          },
+        ]
+      : [];
+  },
+};
+
+export default nextConfig;

--- a/apps/enrollment-dashboard/package.json
+++ b/apps/enrollment-dashboard/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "enrollment-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build --turbopack",
+    "start": "next start",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@repo/backend": "workspace:^",
+    "convex": "^1.16.0",
+    "next": "15.5.2",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@repo/tailwind-config": "workspace:*",
+    "eslint": "^9",
+    "eslint-config-next": "15.5.2",
+    "tailwindcss": "^4",
+    "typescript": "^5"
+  }
+}

--- a/apps/enrollment-dashboard/postcss.config.mjs
+++ b/apps/enrollment-dashboard/postcss.config.mjs
@@ -1,0 +1,5 @@
+const config = {
+  plugins: ["@tailwindcss/postcss"],
+};
+
+export default config;

--- a/apps/enrollment-dashboard/public/css/styles.css
+++ b/apps/enrollment-dashboard/public/css/styles.css
@@ -1,0 +1,503 @@
+/* OneDigital Brand Colors */
+:root {
+  /* Primary OneDigital Colors */
+  --od-blue: #007ba2;
+  --od-blue-light: rgba(0, 123, 162, 0.1);
+  --od-blue-50: rgba(0, 123, 162, 0.05);
+  --od-blue-75: rgba(0, 123, 162, 0.75);
+  --od-blue-90: rgba(0, 123, 162, 0.9);
+
+  --od-green: #8fb554;
+  --od-green-light: rgba(143, 181, 84, 0.1);
+  --od-green-50: rgba(143, 181, 84, 0.05);
+  --od-green-75: rgba(143, 181, 84, 0.75);
+
+  --od-orange: #f49d20;
+  --od-orange-light: rgba(244, 157, 32, 0.1);
+  --od-orange-50: rgba(244, 157, 32, 0.05);
+  --od-orange-75: rgba(244, 157, 32, 0.75);
+
+  --od-gray: #909198;
+  --od-gray-light: rgba(144, 145, 152, 0.1);
+  --od-gray-dark: #6b6c73;
+  --od-gray-darker: #4a4b52;
+
+  /* OneDigital Navy for backgrounds */
+  --od-navy: #1e3a5f;
+}
+
+/* Body background styling */
+body {
+  background-color: var(--od-navy) !important;
+  min-height: 100vh;
+}
+
+html,
+body {
+  background-color: var(--od-navy) !important;
+  background: var(--od-navy) !important;
+}
+
+/* Override default Tailwind colors with OneDigital brand colors */
+.bg-primary {
+  background-color: var(--od-blue);
+}
+.bg-primary-light {
+  background-color: var(--od-blue-light);
+}
+.bg-primary-50 {
+  background-color: var(--od-blue-50);
+}
+.text-primary {
+  color: var(--od-blue);
+}
+.border-primary {
+  border-color: var(--od-blue);
+}
+
+.bg-success {
+  background-color: var(--od-green);
+}
+.bg-success-light {
+  background-color: var(--od-green-light);
+}
+.text-success {
+  color: var(--od-green);
+}
+.border-success {
+  border-color: var(--od-green);
+}
+
+.bg-warning {
+  background-color: var(--od-orange);
+}
+.bg-warning-light {
+  background-color: var(--od-orange-light);
+}
+.text-warning {
+  color: var(--od-orange);
+}
+.border-warning {
+  border-color: var(--od-orange);
+}
+
+.bg-muted {
+  background-color: var(--od-gray);
+}
+.bg-muted-light {
+  background-color: var(--od-gray-light);
+}
+.text-muted {
+  color: var(--od-gray);
+}
+.text-muted-dark {
+  color: var(--od-gray-dark);
+}
+
+/* Navigation styling */
+.nav-primary {
+  background: linear-gradient(
+    135deg,
+    var(--od-blue) 0%,
+    var(--od-blue-90) 100%
+  );
+  box-shadow: 0 2px 10px rgba(0, 123, 162, 0.15);
+}
+
+.nav-link:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  transition: all 0.2s ease-in-out;
+}
+
+/* Default H1 styling - black text */
+h1 {
+  color: black !important;
+}
+
+/* Force white background for main content areas */
+.bg-white {
+  background-color: white !important;
+}
+
+main {
+  background-color: white !important;
+}
+
+/* Sort arrows styling */
+.sort-header {
+  display: flex !important;
+  align-items: center !important;
+  gap: 0.25rem !important;
+  color: #6b7280 !important;
+  text-decoration: none !important;
+}
+
+.sort-header:hover {
+  color: #374151 !important;
+}
+
+.sort-arrow {
+  width: 16px !important;
+  height: 16px !important;
+  flex-shrink: 0 !important;
+}
+
+/* Ensure feather icons display properly */
+.feather {
+  width: 16px !important;
+  height: 16px !important;
+  stroke: currentColor !important;
+  stroke-width: 2 !important;
+  fill: none !important;
+}
+
+/* Table header link styling */
+th a {
+  display: flex !important;
+  align-items: center !important;
+  gap: 0.25rem !important;
+  color: inherit !important;
+  text-decoration: none !important;
+}
+
+/* Button styles with OneDigital colors */
+.btn-primary {
+  background-color: var(--od-blue);
+  border-color: var(--od-blue);
+  color: white;
+  transition: all 0.2s ease-in-out;
+}
+
+.btn-primary:hover:not(.loading) {
+  background-color: var(--od-blue-75);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 123, 162, 0.3);
+}
+
+.btn-primary.loading {
+  background-color: var(--od-blue-75);
+  cursor: not-allowed;
+  position: relative;
+}
+
+.btn-primary.loading:disabled {
+  opacity: 0.8;
+}
+
+.btn-success {
+  background-color: var(--od-green);
+  border-color: var(--od-green);
+  color: white;
+}
+
+.btn-success:hover {
+  background-color: var(--od-green-75);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(143, 181, 84, 0.3);
+}
+
+.btn-warning {
+  background-color: var(--od-orange) !important;
+  border-color: var(--od-orange) !important;
+  color: white !important;
+}
+
+.btn-warning:hover {
+  background-color: var(--od-orange-75) !important;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(244, 157, 32, 0.3);
+}
+
+.btn-orange {
+  background-color: var(--od-orange) !important;
+  border-color: var(--od-orange) !important;
+  color: white !important;
+  transition: all 0.2s ease-in-out;
+}
+
+.btn-orange:hover {
+  background-color: var(--od-orange-75) !important;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(244, 157, 32, 0.3);
+}
+
+/* Card and section styling */
+.card-primary {
+  border-left: 4px solid var(--od-blue);
+  background: linear-gradient(135deg, var(--od-blue-50) 0%, white 100%);
+}
+
+.card-success {
+  border-left: 4px solid var(--od-green);
+  background: linear-gradient(135deg, var(--od-green-50) 0%, white 100%);
+}
+
+.card-warning {
+  border-left: 4px solid var(--od-orange);
+  background: linear-gradient(135deg, var(--od-orange-50) 0%, white 100%);
+}
+
+/* Status badges with OneDigital colors */
+.status-minimal {
+  background-color: var(--od-green-light);
+  color: var(--od-green);
+  border: 1px solid var(--od-green);
+}
+
+.status-low {
+  background-color: var(--od-blue-light);
+  color: var(--od-blue);
+  border: 1px solid var(--od-blue);
+}
+
+.status-moderate {
+  background-color: var(--od-orange-light);
+  color: var(--od-orange);
+  border: 1px solid var(--od-orange);
+}
+
+.status-high {
+  background-color: rgba(220, 38, 38, 0.1);
+  color: #dc2626;
+  border: 1px solid #dc2626;
+}
+
+/* Form styling */
+.form-input:focus {
+  outline: none;
+  border-color: var(--od-blue);
+  box-shadow: 0 0 0 3px var(--od-blue-light);
+}
+
+.form-select:focus {
+  outline: none;
+  border-color: var(--od-blue);
+  box-shadow: 0 0 0 3px var(--od-blue-light);
+}
+
+/* Toast notifications with brand colors */
+.toast {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 9999;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  transform: translateX(100%);
+  transition: all 0.3s ease-in-out;
+  font-weight: 500;
+}
+
+.toast.success {
+  background-color: var(--od-green);
+  color: white;
+  border-left: 4px solid var(--od-green-75);
+}
+
+.toast.error {
+  background-color: #ef4444;
+  color: white;
+  border-left: 4px solid #dc2626;
+}
+
+.toast.info {
+  background-color: var(--od-blue);
+  color: white;
+  border-left: 4px solid var(--od-blue-75);
+}
+
+/* Spinner */
+.spinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid transparent;
+  border-top: 2px solid currentColor;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+/* Form animations */
+.form-section {
+  transition: all 0.3s ease-in-out;
+  border-left: 3px solid transparent;
+}
+
+.form-section.expanded {
+  border-left-color: var(--od-blue);
+  background: linear-gradient(135deg, var(--od-blue-50) 0%, white 100%);
+}
+
+.form-section.collapsed {
+  max-height: 60px;
+  overflow: hidden;
+}
+
+.form-section.expanded {
+  max-height: 1000px;
+}
+
+/* Table styling with brand colors */
+.table-header {
+  background: linear-gradient(
+    135deg,
+    var(--od-blue) 0%,
+    var(--od-blue-90) 100%
+  );
+  color: white;
+}
+
+.table-row:hover {
+  background: linear-gradient(135deg, var(--od-blue-50) 0%, white 100%);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 123, 162, 0.1);
+  transition: all 0.2s ease-in-out;
+}
+
+/* Status badge animations */
+.status-badge {
+  transition: all 0.2s ease-in-out;
+  font-weight: 600;
+}
+
+.status-badge:hover {
+  transform: scale(1.05);
+}
+
+/* Loading states */
+.loading {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.loading-spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  border-top: 2px solid white;
+  animation: spin 0.8s linear infinite;
+  margin-right: 8px;
+}
+
+/* Form submission overlay */
+.form-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.3s ease-in-out;
+}
+
+.form-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.overlay-content {
+  background: white;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 10px 40px rgba(0, 123, 162, 0.15);
+  text-align: center;
+  max-width: 300px;
+  border: 1px solid var(--od-blue-light);
+}
+
+.overlay-spinner {
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(0, 123, 162, 0.1);
+  border-radius: 50%;
+  border-top: 3px solid var(--od-blue);
+  animation: spin 1s linear infinite;
+  margin-bottom: 1rem;
+}
+
+/* Custom scrollbar with brand colors */
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: var(--od-gray-light);
+  border-radius: 3px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: var(--od-gray);
+  border-radius: 3px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: var(--od-gray-dark);
+}
+
+/* Focus styles with brand colors */
+.focus-ring:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--od-blue-light);
+  border-color: var(--od-blue);
+}
+
+/* Hero section styling */
+.hero-gradient {
+  background: linear-gradient(
+    135deg,
+    var(--od-blue) 0%,
+    var(--od-blue-90) 50%,
+    var(--od-green) 100%
+  );
+}
+
+/* Section headers */
+.section-header {
+  color: var(--od-blue);
+  border-bottom: 2px solid var(--od-blue-light);
+  font-weight: 700;
+}
+
+/* Links */
+.link-primary {
+  color: var(--od-blue);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: all 0.2s ease-in-out;
+}
+
+.link-primary:hover {
+  border-bottom-color: var(--od-blue);
+  color: var(--od-blue-75);
+}
+
+/* Print styles */
+@media print {
+  .no-print {
+    display: none !important;
+  }
+
+  .print-full-width {
+    width: 100% !important;
+  }
+}

--- a/apps/enrollment-dashboard/public/js/dashboard.js
+++ b/apps/enrollment-dashboard/public/js/dashboard.js
@@ -1,0 +1,433 @@
+// Dashboard functionality for Enrollment Guide application
+
+document.addEventListener("DOMContentLoaded", function () {
+  initializeStatusSelects();
+  initializeTableSorting();
+  initializeFilters();
+  initializeKeyboardShortcuts();
+  loadLiveStats();
+});
+
+// Status update functionality
+function initializeStatusSelects() {
+  const statusSelects = document.querySelectorAll(".status-select");
+
+  statusSelects.forEach((select) => {
+    const originalStatus = select.value;
+
+    select.addEventListener("change", function (e) {
+      const intakeId = this.dataset.intakeId;
+      const newStatus = this.value;
+      const selectElement = this;
+
+      // Add loading state
+      selectElement.disabled = true;
+      selectElement.style.opacity = "0.6";
+
+      // Update status via API
+      fetch(`/intakes/${intakeId}/status`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ status: newStatus }),
+      })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+          return response.json();
+        })
+        .then((data) => {
+          if (data.success) {
+            showToast("Status updated successfully", "success");
+            // Update the current status data attribute
+            selectElement.dataset.currentStatus = newStatus;
+            // Update the visual styling
+            updateStatusStyling(selectElement, newStatus);
+
+            // Dispatch custom event to trigger stats update
+            const statusChangedEvent = new CustomEvent("statusChanged", {
+              detail: { intakeId, oldStatus: originalStatus, newStatus },
+            });
+            document.dispatchEvent(statusChangedEvent);
+          } else {
+            throw new Error(data.error || "Failed to update status");
+          }
+        })
+        .catch((error) => {
+          console.error("Error updating status:", error);
+          showToast("Failed to update status: " + error.message, "error");
+          // Revert to original status
+          selectElement.value = originalStatus;
+        })
+        .finally(() => {
+          // Remove loading state
+          selectElement.disabled = false;
+          selectElement.style.opacity = "1";
+        });
+    });
+  });
+}
+
+// Update status select styling based on status
+function updateStatusStyling(selectElement, status) {
+  // Remove all status classes
+  const statusClasses = [
+    "bg-gray-100",
+    "text-gray-800",
+    "bg-blue-100",
+    "text-blue-800",
+    "bg-red-100",
+    "text-red-800",
+    "bg-yellow-100",
+    "text-yellow-800",
+    "bg-green-100",
+    "text-green-800",
+  ];
+
+  selectElement.classList.remove(...statusClasses);
+
+  // Add appropriate classes based on status
+  switch (status) {
+    case "NOT_STARTED":
+      selectElement.classList.add("bg-gray-100", "text-gray-800");
+      break;
+    case "STARTED":
+      selectElement.classList.add("bg-blue-100", "text-blue-800");
+      break;
+    case "ROADBLOCK":
+      selectElement.classList.add("bg-red-100", "text-red-800");
+      break;
+    case "READY_FOR_QA":
+      selectElement.classList.add("bg-yellow-100", "text-yellow-800");
+      break;
+    case "DELIVERED_TO_CONSULTANT":
+      selectElement.classList.add("bg-green-100", "text-green-800");
+      break;
+  }
+}
+
+// Table sorting functionality
+function initializeTableSorting() {
+  const sortableHeaders = document.querySelectorAll('th a[href*="sort="]');
+
+  sortableHeaders.forEach((header) => {
+    header.addEventListener("click", function (e) {
+      // Show loading indicator
+      showLoadingIndicator();
+    });
+  });
+}
+
+// Filter functionality
+function initializeFilters() {
+  const filterForm = document.getElementById("filtersForm");
+  if (!filterForm) return;
+
+  // Auto-submit on filter changes
+  const filterInputs = filterForm.querySelectorAll("select, input");
+  filterInputs.forEach((input) => {
+    input.addEventListener("change", function () {
+      // Small delay to allow for multiple rapid changes
+      clearTimeout(window.filterTimeout);
+      window.filterTimeout = setTimeout(() => {
+        showLoadingIndicator();
+        filterForm.submit();
+      }, 300);
+    });
+  });
+
+  // Handle text input with debouncing
+  const textInputs = filterForm.querySelectorAll('input[type="text"]');
+  textInputs.forEach((input) => {
+    input.addEventListener("input", function () {
+      clearTimeout(window.textFilterTimeout);
+      window.textFilterTimeout = setTimeout(() => {
+        showLoadingIndicator();
+        filterForm.submit();
+      }, 800);
+    });
+  });
+}
+
+// Keyboard shortcuts
+function initializeKeyboardShortcuts() {
+  document.addEventListener("keydown", function (e) {
+    // Ctrl/Cmd + K: Focus search
+    if ((e.ctrlKey || e.metaKey) && e.key === "k") {
+      e.preventDefault();
+      const searchInput = document.querySelector('input[name="requestor"]');
+      if (searchInput) {
+        searchInput.focus();
+        searchInput.select();
+      }
+    }
+
+    // N: New intake (when not in input)
+    if (e.key === "n" && !isInputFocused()) {
+      e.preventDefault();
+      window.location.href = "/intakes/new";
+    }
+
+    // E: Export CSV (when not in input)
+    if (e.key === "e" && !isInputFocused()) {
+      e.preventDefault();
+      const exportLink = document.querySelector('a[href*="export.csv"]');
+      if (exportLink) {
+        window.location.href = exportLink.href;
+      }
+    }
+  });
+}
+
+// Check if an input element is currently focused
+function isInputFocused() {
+  const activeElement = document.activeElement;
+  return (
+    activeElement &&
+    (activeElement.tagName === "INPUT" ||
+      activeElement.tagName === "TEXTAREA" ||
+      activeElement.tagName === "SELECT" ||
+      activeElement.contentEditable === "true")
+  );
+}
+
+// Load live statistics
+function loadLiveStats() {
+  // Simple implementation - in a real app, this might poll an API
+  const statsElement = document.getElementById("live-stats");
+  if (statsElement) {
+    // Update with current page info
+    const totalRows = document.querySelectorAll("tbody tr").length;
+    if (totalRows > 0) {
+      statsElement.textContent = `${totalRows} items shown`;
+    } else {
+      statsElement.textContent = "No items";
+    }
+  }
+}
+
+// Toast notification system
+function showToast(message, type = "success") {
+  const toast = document.createElement("div");
+  toast.className = `toast ${type} translate-x-full`;
+  toast.textContent = message;
+
+  document.body.appendChild(toast);
+
+  // Slide in
+  setTimeout(() => {
+    toast.classList.remove("translate-x-full");
+  }, 100);
+
+  // Slide out and remove
+  setTimeout(() => {
+    toast.classList.add("translate-x-full");
+    setTimeout(() => {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast);
+      }
+    }, 300);
+  }, 3000);
+}
+
+// Loading indicator
+function showLoadingIndicator() {
+  // Create or show loading indicator
+  let loader = document.getElementById("loading-indicator");
+  if (!loader) {
+    loader = document.createElement("div");
+    loader.id = "loading-indicator";
+    loader.className =
+      "fixed top-4 left-1/2 transform -translate-x-1/2 bg-blue-600 text-white px-4 py-2 rounded-lg shadow-lg z-50 flex items-center gap-2";
+    loader.innerHTML = '<div class="spinner"></div> Loading...';
+    document.body.appendChild(loader);
+  }
+
+  loader.style.display = "flex";
+
+  // Hide after a reasonable time
+  setTimeout(() => {
+    if (loader) {
+      loader.style.display = "none";
+    }
+  }, 2000);
+}
+
+// Row click handling for navigation
+document.addEventListener("click", function (e) {
+  const row = e.target.closest("tr[onclick]");
+  if (
+    row &&
+    !e.target.closest(".status-select") &&
+    !e.target.closest("a") &&
+    !e.target.closest("button")
+  ) {
+    // Extract the onclick attribute and execute it
+    const onclick = row.getAttribute("onclick");
+    if (onclick) {
+      eval(onclick);
+    }
+  }
+});
+
+// Bulk actions (if implemented in the future)
+function initializeBulkActions() {
+  const selectAllCheckbox = document.getElementById("select-all");
+  const rowCheckboxes = document.querySelectorAll(".row-checkbox");
+  const bulkActionButtons = document.querySelectorAll(".bulk-action");
+
+  if (selectAllCheckbox) {
+    selectAllCheckbox.addEventListener("change", function () {
+      rowCheckboxes.forEach((checkbox) => {
+        checkbox.checked = this.checked;
+      });
+      updateBulkActionButtons();
+    });
+  }
+
+  rowCheckboxes.forEach((checkbox) => {
+    checkbox.addEventListener("change", updateBulkActionButtons);
+  });
+
+  function updateBulkActionButtons() {
+    const checkedCount = document.querySelectorAll(
+      ".row-checkbox:checked",
+    ).length;
+    bulkActionButtons.forEach((button) => {
+      button.disabled = checkedCount === 0;
+      button.textContent = button.textContent.replace(
+        /\(\d+\)/,
+        `(${checkedCount})`,
+      );
+    });
+  }
+}
+
+// Export functionality enhancement
+function enhancedExport() {
+  const exportButtons = document.querySelectorAll('a[href*="export.csv"]');
+
+  exportButtons.forEach((button) => {
+    button.addEventListener("click", function (e) {
+      // Show loading state
+      const originalText = this.textContent;
+      this.innerHTML = '<div class="spinner mr-2"></div> Exporting...';
+      this.style.pointerEvents = "none";
+
+      // Reset after a delay (the download should start)
+      setTimeout(() => {
+        this.textContent = originalText;
+        this.style.pointerEvents = "auto";
+        showToast("Export started - check your downloads", "info");
+      }, 1000);
+    });
+  });
+}
+
+// Initialize enhanced features
+document.addEventListener("DOMContentLoaded", function () {
+  enhancedExport();
+  // initializeBulkActions(); // Uncomment when bulk actions are implemented
+});
+
+// Global function to make showToast available to other scripts
+window.showToast = showToast;
+
+// Utility function for formatting dates
+function formatDate(dateString) {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+// Utility function for formatting relative time
+function formatRelativeTime(dateString) {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffInHours = (now - date) / (1000 * 60 * 60);
+
+  if (diffInHours < 1) {
+    return "Just now";
+  } else if (diffInHours < 24) {
+    return `${Math.floor(diffInHours)} hours ago`;
+  } else if (diffInHours < 48) {
+    return "Yesterday";
+  } else {
+    return `${Math.floor(diffInHours / 24)} days ago`;
+  }
+}
+
+// Performance optimization: Debounce function
+function debounce(func, wait) {
+  let timeout;
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}
+
+// Error handling for network requests
+function handleNetworkError(error) {
+  console.error("Network error:", error);
+  if (error.name === "TypeError" && error.message.includes("fetch")) {
+    showToast("Network error - please check your connection", "error");
+  } else {
+    showToast("An unexpected error occurred", "error");
+  }
+}
+
+// Delete intake functionality
+function deleteIntake(intakeId, clientName) {
+  if (
+    confirm(
+      `Are you sure you want to delete the intake for "${clientName}"? This action cannot be undone.`,
+    )
+  ) {
+    // Show loading state
+    showToast("Deleting intake...", "info");
+
+    fetch(`/intakes/${intakeId}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((data) => {
+        if (data.success) {
+          showToast("Intake deleted successfully", "success");
+          // Refresh the page to update the list
+          setTimeout(() => {
+            window.location.reload();
+          }, 1000);
+        } else {
+          throw new Error(data.error || "Failed to delete intake");
+        }
+      })
+      .catch((error) => {
+        console.error("Error deleting intake:", error);
+        showToast("Failed to delete intake: " + error.message, "error");
+      });
+  }
+}
+
+// Make utility functions available globally
+window.formatDate = formatDate;
+window.formatRelativeTime = formatRelativeTime;
+window.debounce = debounce;
+window.handleNetworkError = handleNetworkError;
+window.deleteIntake = deleteIntake;

--- a/apps/enrollment-dashboard/public/js/intake-form.js
+++ b/apps/enrollment-dashboard/public/js/intake-form.js
@@ -1,0 +1,412 @@
+// Intake form functionality for multi-step wizard
+
+document.addEventListener("DOMContentLoaded", function () {
+  initializeFormValidation();
+  initializeSectionToggles();
+  initializePlanBlocks();
+  initializeFormPersistence();
+  initializeProgressTracking();
+});
+
+// Form validation
+function initializeFormValidation() {
+  const form = document.getElementById("intakeForm");
+  if (!form) return;
+
+  form.addEventListener("submit", function (e) {
+    const currentStep = parseInt(
+      document.querySelector('input[name="step"]').value,
+    );
+
+    if (!validateCurrentStep(currentStep)) {
+      e.preventDefault();
+      showToast("Please fix the errors before continuing", "error");
+    }
+  });
+
+  // Real-time validation
+  const inputs = form.querySelectorAll("input[required], select[required]");
+  inputs.forEach((input) => {
+    input.addEventListener("blur", function () {
+      validateField(this);
+    });
+
+    input.addEventListener("input", function () {
+      clearFieldError(this);
+    });
+  });
+}
+
+// Validate individual field
+function validateField(field) {
+  const value = field.value.trim();
+  const isValid = field.checkValidity();
+
+  clearFieldError(field);
+
+  if (!isValid || (field.required && !value)) {
+    showFieldError(field, getFieldErrorMessage(field));
+    return false;
+  }
+
+  return true;
+}
+
+// Get appropriate error message for field
+function getFieldErrorMessage(field) {
+  if (field.validity.valueMissing) {
+    return `${getFieldLabel(field)} is required`;
+  }
+  if (field.validity.typeMismatch) {
+    if (field.type === "email") {
+      return "Please enter a valid email address";
+    }
+  }
+  if (field.validity.rangeUnderflow) {
+    return `Value must be at least ${field.min}`;
+  }
+  if (field.validity.rangeOverflow) {
+    return `Value must be no more than ${field.max}`;
+  }
+  return "Please enter a valid value";
+}
+
+// Get field label text
+function getFieldLabel(field) {
+  const label = document.querySelector(`label[for="${field.id}"]`);
+  if (label) {
+    return label.textContent.replace("*", "").trim();
+  }
+  return field.name.replace(/_/g, " ");
+}
+
+// Show field error
+function showFieldError(field, message) {
+  clearFieldError(field);
+
+  field.classList.add(
+    "border-red-300",
+    "focus:border-red-500",
+    "focus:ring-red-500",
+  );
+
+  const errorElement = document.createElement("p");
+  errorElement.className = "mt-1 text-sm text-red-600 field-error";
+  errorElement.textContent = message;
+
+  field.parentNode.appendChild(errorElement);
+}
+
+// Clear field error
+function clearFieldError(field) {
+  field.classList.remove(
+    "border-red-300",
+    "focus:border-red-500",
+    "focus:ring-red-500",
+  );
+
+  const existingError = field.parentNode.querySelector(".field-error");
+  if (existingError) {
+    existingError.remove();
+  }
+}
+
+// Validate current step
+function validateCurrentStep(step) {
+  const form = document.getElementById("intakeForm");
+  let isValid = true;
+
+  if (step === 1) {
+    // Validate basic information
+    const requiredFields = ["client_name", "plan_year", "requestor_name"];
+    requiredFields.forEach((fieldName) => {
+      const field = form.querySelector(`[name="${fieldName}"]`);
+      if (field && !validateField(field)) {
+        isValid = false;
+      }
+    });
+
+    // Validate email if provided
+    const emailField = form.querySelector('[name="requestor_email"]');
+    if (emailField && emailField.value && !validateField(emailField)) {
+      isValid = false;
+    }
+  }
+
+  return isValid;
+}
+
+// Section toggle functionality
+function initializeSectionToggles() {
+  const sectionRadios = document.querySelectorAll(
+    'input[type="radio"][name*="_changed"]',
+  );
+
+  sectionRadios.forEach((radio) => {
+    radio.addEventListener("change", function () {
+      const sectionCode = this.name.split("_")[1]; // Extract section code
+      const isChanged = this.value === "yes";
+
+      toggleSectionDetails(sectionCode, isChanged);
+    });
+  });
+}
+
+// Toggle section details visibility
+function toggleSectionDetails(sectionCode, showDetails) {
+  const noChangesDiv = document.getElementById(`no-changes-${sectionCode}`);
+  const yesChangesDiv = document.getElementById(`yes-changes-${sectionCode}`);
+
+  if (noChangesDiv && yesChangesDiv) {
+    if (showDetails) {
+      noChangesDiv.classList.add("hidden");
+      yesChangesDiv.classList.remove("hidden");
+    } else {
+      noChangesDiv.classList.remove("hidden");
+      yesChangesDiv.classList.add("hidden");
+    }
+  }
+}
+
+// Plan block functionality for multi-plan sections
+function initializePlanBlocks() {
+  // Handle dynamic plan addition/removal if needed
+  const addPlanButtons = document.querySelectorAll(".add-plan-btn");
+  const removePlanButtons = document.querySelectorAll(".remove-plan-btn");
+
+  addPlanButtons.forEach((button) => {
+    button.addEventListener("click", function () {
+      const sectionCode = this.dataset.section;
+      addPlanBlock(sectionCode);
+    });
+  });
+
+  removePlanButtons.forEach((button) => {
+    button.addEventListener("click", function () {
+      const planBlock = this.closest(".plan-block");
+      if (planBlock) {
+        removePlanBlock(planBlock);
+      }
+    });
+  });
+}
+
+// Add new plan block (for future enhancement)
+function addPlanBlock(sectionCode) {
+  console.log(`Adding plan block for section ${sectionCode}`);
+  // Implementation would clone existing plan block and update field names
+}
+
+// Remove plan block (for future enhancement)
+function removePlanBlock(planBlock) {
+  if (confirm("Are you sure you want to remove this plan?")) {
+    planBlock.remove();
+    updatePlanNumbers();
+  }
+}
+
+// Update plan numbers after removal
+function updatePlanNumbers() {
+  const planBlocks = document.querySelectorAll(".plan-block");
+  planBlocks.forEach((block, index) => {
+    const title = block.querySelector("h4");
+    if (title) {
+      title.textContent = `Plan ${index + 1}`;
+    }
+  });
+}
+
+// Form data persistence across steps
+function initializeFormPersistence() {
+  const form = document.getElementById("intakeForm");
+  if (!form) return;
+
+  // Save form data to sessionStorage on input changes
+  const inputs = form.querySelectorAll("input, select, textarea");
+  inputs.forEach((input) => {
+    input.addEventListener("change", function () {
+      saveFormData();
+    });
+  });
+
+  // Load saved data on page load
+  loadFormData();
+}
+
+// Save form data to session storage
+function saveFormData() {
+  const form = document.getElementById("intakeForm");
+  const formData = new FormData(form);
+  const data = {};
+
+  for (let [key, value] of formData.entries()) {
+    data[key] = value;
+  }
+
+  sessionStorage.setItem("intakeFormData", JSON.stringify(data));
+}
+
+// Load form data from session storage
+function loadFormData() {
+  const savedData = sessionStorage.getItem("intakeFormData");
+  if (!savedData) return;
+
+  try {
+    const data = JSON.parse(savedData);
+    const form = document.getElementById("intakeForm");
+
+    Object.entries(data).forEach(([key, value]) => {
+      const field = form.querySelector(`[name="${key}"]`);
+      if (field) {
+        if (field.type === "radio" || field.type === "checkbox") {
+          field.checked = field.value === value;
+        } else {
+          field.value = value;
+        }
+
+        // Trigger change event to update UI
+        field.dispatchEvent(new Event("change"));
+      }
+    });
+  } catch (error) {
+    console.error("Error loading form data:", error);
+  }
+}
+
+// Progress tracking
+function initializeProgressTracking() {
+  updateProgressIndicators();
+}
+
+// Update progress step indicators
+function updateProgressIndicators() {
+  const currentStep = parseInt(
+    document.querySelector('input[name="step"]').value,
+  );
+  const progressSteps = document.querySelectorAll(".progress-step");
+  const progressLines = document.querySelectorAll(".progress-line");
+
+  progressSteps.forEach((step, index) => {
+    const stepNumber = index + 1;
+
+    if (stepNumber < currentStep) {
+      step.classList.add("completed");
+      step.classList.remove("active", "inactive");
+    } else if (stepNumber === currentStep) {
+      step.classList.add("active");
+      step.classList.remove("completed", "inactive");
+    } else {
+      step.classList.add("inactive");
+      step.classList.remove("active", "completed");
+    }
+  });
+
+  progressLines.forEach((line, index) => {
+    if (index + 1 < currentStep) {
+      line.classList.add("completed");
+      line.classList.remove("inactive");
+    } else {
+      line.classList.add("inactive");
+      line.classList.remove("completed");
+    }
+  });
+}
+
+// Utility functions
+function showToast(message, type = "info") {
+  // Use the global toast function if available, otherwise create simple alert
+  if (window.showToast) {
+    window.showToast(message, type);
+  } else {
+    alert(message);
+  }
+}
+
+// Auto-save functionality
+let autoSaveTimer;
+function initializeAutoSave() {
+  const inputs = document.querySelectorAll("input, select, textarea");
+
+  inputs.forEach((input) => {
+    input.addEventListener("input", function () {
+      clearTimeout(autoSaveTimer);
+      autoSaveTimer = setTimeout(() => {
+        saveFormData();
+        showAutoSaveIndicator();
+      }, 2000); // Save after 2 seconds of inactivity
+    });
+  });
+}
+
+// Show auto-save indicator
+function showAutoSaveIndicator() {
+  let indicator = document.getElementById("autosave-indicator");
+  if (!indicator) {
+    indicator = document.createElement("div");
+    indicator.id = "autosave-indicator";
+    indicator.className =
+      "fixed bottom-4 right-4 bg-green-500 text-white px-3 py-1 rounded text-sm opacity-0 transition-opacity";
+    indicator.textContent = "Draft saved";
+    document.body.appendChild(indicator);
+  }
+
+  indicator.style.opacity = "1";
+  setTimeout(() => {
+    indicator.style.opacity = "0";
+  }, 2000);
+}
+
+// Clear saved form data when form is successfully submitted
+function clearSavedFormData() {
+  sessionStorage.removeItem("intakeFormData");
+}
+
+// Handle form submission completion
+document.addEventListener("DOMContentLoaded", function () {
+  // If we're on the success page or redirected, clear saved data
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get("created") === "1") {
+    clearSavedFormData();
+  }
+});
+
+// Keyboard shortcuts for form navigation
+document.addEventListener("keydown", function (e) {
+  if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") {
+    return; // Don't interfere with typing in fields
+  }
+
+  // Alt + Right arrow: Next step
+  if (e.altKey && e.key === "ArrowRight") {
+    e.preventDefault();
+    const nextButton = document.querySelector('button[type="submit"]');
+    if (nextButton) {
+      nextButton.click();
+    }
+  }
+
+  // Alt + Left arrow: Previous step
+  if (e.altKey && e.key === "ArrowLeft") {
+    e.preventDefault();
+    const prevButton = document.querySelector(
+      'button[onclick*="history.back"]',
+    );
+    if (prevButton) {
+      prevButton.click();
+    }
+  }
+});
+
+// Initialize enhanced features when DOM is ready
+document.addEventListener("DOMContentLoaded", function () {
+  initializeAutoSave();
+});
+
+// Export functions for potential use by other scripts
+window.IntakeForm = {
+  validateField,
+  showToast,
+  toggleSectionDetails,
+  saveFormData,
+  loadFormData,
+};

--- a/apps/enrollment-dashboard/src/app/globals.css
+++ b/apps/enrollment-dashboard/src/app/globals.css
@@ -1,0 +1,2 @@
+@import "tailwindcss";
+@import "@repo/tailwind-config";

--- a/apps/enrollment-dashboard/src/app/layout.tsx
+++ b/apps/enrollment-dashboard/src/app/layout.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { Geist, Geist_Mono } from "next/font/google";
+import "./globals.css";
+import { Providers } from "./providers";
+
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: "Enrollment Dashboard",
+  description: "Enrollment dashboard",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+      >
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/apps/enrollment-dashboard/src/app/page.tsx
+++ b/apps/enrollment-dashboard/src/app/page.tsx
@@ -1,0 +1,10 @@
+import { Button } from "@repo/ui/components/ui/button";
+
+export default function Home() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Enrollment Dashboard</h1>
+      <Button>Example Button</Button>
+    </main>
+  );
+}

--- a/apps/enrollment-dashboard/src/app/providers.tsx
+++ b/apps/enrollment-dashboard/src/app/providers.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ConvexProvider, ConvexReactClient } from "convex/react";
+import { ReactNode, useMemo } from "react";
+
+export function Providers({ children }: { children: ReactNode }) {
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+  const client = useMemo(() => new ConvexReactClient(convexUrl!), [convexUrl]);
+
+  return <ConvexProvider client={client}>{children}</ConvexProvider>;
+}

--- a/apps/enrollment-dashboard/tsconfig.json
+++ b/apps/enrollment-dashboard/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/enrollment-dashboard/vercel.json
+++ b/apps/enrollment-dashboard/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "node ../../scripts/turbo-ignore.js",
+  "buildCommand": "npx convex deploy --cmd 'pnpm build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,55 @@ importers:
         specifier: 5.9.2
         version: 5.9.2
 
+  apps/enrollment-dashboard:
+    dependencies:
+      '@repo/backend':
+        specifier: workspace:^
+        version: link:../../packages/backend
+      convex:
+        specifier: ^1.16.0
+        version: 1.26.2(react@19.1.0)
+      next:
+        specifier: 15.5.2
+        version: 15.5.2(react-dom@19.1.0)(react@19.1.0)
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3
+        version: 3.3.1
+      '@repo/tailwind-config':
+        specifier: workspace:*
+        version: link:../../packages/tailwind-config
+      '@tailwindcss/postcss':
+        specifier: ^4
+        version: 4.1.5
+      '@types/node':
+        specifier: ^20
+        version: 20.19.11
+      '@types/react':
+        specifier: ^19
+        version: 19.1.12
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.1.9(@types/react@19.1.12)
+      eslint:
+        specifier: ^9
+        version: 9.33.0
+      eslint-config-next:
+        specifier: 15.5.2
+        version: 15.5.2(eslint@9.33.0)(typescript@5.9.2)
+      tailwindcss:
+        specifier: ^4
+        version: 4.1.5
+      typescript:
+        specifier: ^5
+        version: 5.9.2
+
   apps/host:
     dependencies:
       convex:
@@ -227,7 +276,7 @@ importers:
     dependencies:
       convex:
         specifier: ^1.16.0
-        version: 1.26.2(react@19.1.0)
+        version: 1.26.2(react@19.1.1)
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -4875,7 +4924,7 @@ packages:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
     dependencies:
       aria-query: 5.3.2
-      array-includes: 3.1.8
+      array-includes: 3.1.9
       array.prototype.flatmap: 1.3.3
       ast-types-flow: 0.0.8
       axe-core: 4.10.3


### PR DESCRIPTION
## Summary
- scaffold `enrollment-dashboard` Next.js app in `apps/` with monorepo config
- hook up shared Tailwind theme, UI package, and Convex provider
- migrate existing static assets into app `public`

## Testing
- `pnpm lint --filter enrollment-dashboard`
- `pnpm check-types --filter enrollment-dashboard`


------
https://chatgpt.com/codex/tasks/task_b_68b532c0d3e0832dbfb84dd6c8a87a96